### PR TITLE
Rename 'Tutorial' -> 'Tutorial Overview'

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,6 +1,6 @@
-========
-Tutorial
-========
+=================
+Tutorial Overview
+=================
 
 Learn how to write browser automation tests in basil.
 


### PR DESCRIPTION
Fixes #99