### PR TITLE
Differentiate literal text and variable names in syntax definitions

### DIFF
--- a/docs/includes/syntax/action/action.rst
+++ b/docs/includes/syntax/action/action.rst
@@ -1,6 +1,6 @@
 .. code-block:: text
 
-    verb [arguments-section]
+    verb [{arguments-section}]
 
     verb:
         back
@@ -13,12 +13,12 @@
         wait
         wait-for
 
-    arguments-section:
-        [argument [keyword [argument]]]
+    {arguments-section}:
+        [{argument} [{keyword} [{argument}]]]
 
-    argument:
+    {argument}:
         <string>, double-quoted
 
-    keyword:
+    {keyword}:
         in
         to

--- a/docs/includes/syntax/action/click.rst
+++ b/docs/includes/syntax/action/click.rst
@@ -1,6 +1,6 @@
 .. code-block:: text
 
-    click identifier
+    click {identifier}
 
-    identifier:
+    {identifier}:
         <identifier-string>

--- a/docs/includes/syntax/action/open.rst
+++ b/docs/includes/syntax/action/open.rst
@@ -1,10 +1,10 @@
 .. code-block:: text
 
-    open "url" in "browser"
+    open "{url}" in "{browser}"
 
-    url:
+    {url}:
         <url-string>
 
-    browser:
+    {browser}:
         chrome
         firefox

--- a/docs/includes/syntax/action/set.rst
+++ b/docs/includes/syntax/action/set.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    set identifier to "value"
+    set {identifier} to "{value}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/action/submit.rst
+++ b/docs/includes/syntax/action/submit.rst
@@ -1,6 +1,6 @@
 .. code-block:: text
 
-    submit identifier
+    submit {identifier}
 
-    identifier:
+    {identifier}:
         <identifier-string>

--- a/docs/includes/syntax/action/wait-for.rst
+++ b/docs/includes/syntax/action/wait-for.rst
@@ -1,6 +1,6 @@
 .. code-block:: text
 
-    wait-for identifier
+    wait-for {identifier}
 
-    identifier:
+    {identifier}:
         <identifier-string>

--- a/docs/includes/syntax/action/wait.rst
+++ b/docs/includes/syntax/action/wait.rst
@@ -1,6 +1,6 @@
 .. code-block:: text
 
-    wait number-of-seconds
+    wait {number-of-seconds}
 
-    number-of-seconds:
+    {number-of-seconds}:
         <integer>, greater than zero

--- a/docs/includes/syntax/assertion/assertion.rst
+++ b/docs/includes/syntax/assertion/assertion.rst
@@ -1,16 +1,16 @@
 .. code-block:: text
 
-    identifier comparison [value]
+    {identifier} {comparison} [{value}]
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    comparison:
+    {comparison}:
         excludes
         includes
         is
         is-not
         matches
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/assertion/excludes.rst
+++ b/docs/includes/syntax/assertion/excludes.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    identifier excludes "value"
+    {identifier} excludes "{value}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/assertion/includes.rst
+++ b/docs/includes/syntax/assertion/includes.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    identifier includes "value"
+    {identifier} includes "{value}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/assertion/is-not.rst
+++ b/docs/includes/syntax/assertion/is-not.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    identifier is-not "value"
+    {identifier} is-not "{value}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/assertion/is.rst
+++ b/docs/includes/syntax/assertion/is.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    identifier is "value"
+    {identifier} is "{value}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    value:
+    {value}:
         <string>

--- a/docs/includes/syntax/assertion/matches.rst
+++ b/docs/includes/syntax/assertion/matches.rst
@@ -1,9 +1,9 @@
 .. code-block:: text
 
-    identifier matches "regex"
+    {identifier} matches "{regex}"
 
-    identifier:
+    {identifier}:
         <identifier-string>
 
-    regex:
+    {regex}:
         <regular-expression>


### PR DESCRIPTION
Fixes #141